### PR TITLE
Bugfix: Player can climb walls

### DIFF
--- a/Assets/PhysicsMaterials.meta
+++ b/Assets/PhysicsMaterials.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7f05bce4cf9aa439da1cfe015004a548
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PhysicsMaterials/Frictionless.physicsMaterial2D
+++ b/Assets/PhysicsMaterials/Frictionless.physicsMaterial2D
@@ -1,0 +1,11 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!62 &6200000
+PhysicsMaterial2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Frictionless
+  friction: 0
+  bounciness: 0

--- a/Assets/PhysicsMaterials/Frictionless.physicsMaterial2D.meta
+++ b/Assets/PhysicsMaterials/Frictionless.physicsMaterial2D.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 02a93e0fbb3cd49a981ccae95b5aa8a4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 6200000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/SystemTests/EnemyTest.unity
+++ b/Assets/Scenes/SystemTests/EnemyTest.unity
@@ -403,6 +403,16 @@ PrefabInstance:
       propertyPath: m_Mesh
       value: 
       objectReference: {fileID: 1324587654}
+    - target: {fileID: 4126313714793212233, guid: 4c1d3068d838b4969bf594038cd4ca03,
+        type: 3}
+      propertyPath: runSpeed
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4126313714793212233, guid: 4c1d3068d838b4969bf594038cd4ca03,
+        type: 3}
+      propertyPath: walkSpeed
+      value: 7
+      objectReference: {fileID: 0}
     - target: {fileID: 5033854430437854709, guid: 4c1d3068d838b4969bf594038cd4ca03,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -2838,6 +2848,7 @@ GameObject:
   - component: {fileID: 743361288}
   - component: {fileID: 743361287}
   - component: {fileID: 743361286}
+  - component: {fileID: 743361289}
   m_Layer: 7
   m_Name: Platform
   m_TagString: Ground
@@ -2875,7 +2886,7 @@ BoxCollider2D:
     serializedVersion: 2
     m_Bits: 4294967295
   m_IsTrigger: 0
-  m_UsedByEffector: 0
+  m_UsedByEffector: 1
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
   m_SpriteTilingProperty:
@@ -2958,6 +2969,25 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!251 &743361289
+PlatformEffector2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 743361285}
+  m_Enabled: 1
+  m_UseColliderMask: 1
+  m_ColliderMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RotationalOffset: 0
+  m_UseOneWay: 1
+  m_UseOneWayGrouping: 0
+  m_SurfaceArc: 180
+  m_UseSideFriction: 0
+  m_UseSideBounce: 0
+  m_SideArc: 1
 --- !u!21 &777577532
 Material:
   serializedVersion: 8
@@ -5281,6 +5311,7 @@ GameObject:
   - component: {fileID: 1584422748}
   - component: {fileID: 1584422747}
   - component: {fileID: 1584422746}
+  - component: {fileID: 1584422749}
   m_Layer: 7
   m_Name: Platform (2)
   m_TagString: Ground
@@ -5318,7 +5349,7 @@ BoxCollider2D:
     serializedVersion: 2
     m_Bits: 4294967295
   m_IsTrigger: 0
-  m_UsedByEffector: 0
+  m_UsedByEffector: 1
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
   m_SpriteTilingProperty:
@@ -5401,6 +5432,25 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!251 &1584422749
+PlatformEffector2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1584422745}
+  m_Enabled: 1
+  m_UseColliderMask: 1
+  m_ColliderMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RotationalOffset: 0
+  m_UseOneWay: 1
+  m_UseOneWayGrouping: 0
+  m_SurfaceArc: 180
+  m_UseSideFriction: 0
+  m_UseSideBounce: 0
+  m_SideArc: 1
 --- !u!1 &1633523296
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/SystemTests/EnemyTest.unity
+++ b/Assets/Scenes/SystemTests/EnemyTest.unity
@@ -2848,7 +2848,6 @@ GameObject:
   - component: {fileID: 743361288}
   - component: {fileID: 743361287}
   - component: {fileID: 743361286}
-  - component: {fileID: 743361289}
   m_Layer: 7
   m_Name: Platform
   m_TagString: Ground
@@ -2969,25 +2968,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!251 &743361289
-PlatformEffector2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 743361285}
-  m_Enabled: 1
-  m_UseColliderMask: 1
-  m_ColliderMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_RotationalOffset: 0
-  m_UseOneWay: 1
-  m_UseOneWayGrouping: 0
-  m_SurfaceArc: 180
-  m_UseSideFriction: 0
-  m_UseSideBounce: 0
-  m_SideArc: 1
 --- !u!21 &777577532
 Material:
   serializedVersion: 8
@@ -5311,7 +5291,6 @@ GameObject:
   - component: {fileID: 1584422748}
   - component: {fileID: 1584422747}
   - component: {fileID: 1584422746}
-  - component: {fileID: 1584422749}
   m_Layer: 7
   m_Name: Platform (2)
   m_TagString: Ground
@@ -5432,25 +5411,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!251 &1584422749
-PlatformEffector2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1584422745}
-  m_Enabled: 1
-  m_UseColliderMask: 1
-  m_ColliderMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_RotationalOffset: 0
-  m_UseOneWay: 1
-  m_UseOneWayGrouping: 0
-  m_SurfaceArc: 180
-  m_UseSideFriction: 0
-  m_UseSideBounce: 0
-  m_SideArc: 1
 --- !u!1 &1633523296
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/SystemTests/MovementTest.unity
+++ b/Assets/Scenes/SystemTests/MovementTest.unity
@@ -73098,7 +73098,7 @@ CapsuleCollider2D:
   m_GameObject: {fileID: 705094709939240469}
   m_Enabled: 1
   m_Density: 1
-  m_Material: {fileID: 6200000, guid: 0a8df57921651b54aa3686cd5cce2c77, type: 2}
+  m_Material: {fileID: 6200000, guid: 02a93e0fbb3cd49a981ccae95b5aa8a4, type: 2}
   m_IncludeLayers:
     serializedVersion: 2
     m_Bits: 0

--- a/Assets/Scenes/SystemTests/MovementTest.unity
+++ b/Assets/Scenes/SystemTests/MovementTest.unity
@@ -34122,6 +34122,7 @@ GameObject:
   - component: {fileID: 7064471818154523215}
   - component: {fileID: 1173779478072404077}
   - component: {fileID: 8725177556520088304}
+  - component: {fileID: 8725177556520088305}
   - component: {fileID: 2957042245170381098}
   m_Layer: 0
   m_Name: Player
@@ -60804,7 +60805,7 @@ Rigidbody2D:
   m_LinearDrag: 0
   m_AngularDrag: 0.05
   m_GravityScale: 1
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 6200000, guid: 02a93e0fbb3cd49a981ccae95b5aa8a4, type: 2}
   m_IncludeLayers:
     serializedVersion: 2
     m_Bits: 0
@@ -73087,6 +73088,41 @@ CapsuleCollider2D:
   m_UsedByComposite: 0
   m_Offset: {x: 0.027848141, y: 0.10025297}
   m_Size: {x: 1.8255677, y: 2.826833}
+  m_Direction: 0
+--- !u!70 &8725177556520088305
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 705094709939240469}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 6200000, guid: 0a8df57921651b54aa3686cd5cce2c77, type: 2}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0.019581659, y: 0.16638398}
+  m_Size: {x: 2.1396909, y: 2.694571}
   m_Direction: 0
 --- !u!23 &8750347208629281974
 MeshRenderer:


### PR DESCRIPTION
Fixes #22 

Adds a second collider to the player with a wider shape (but not covering feet) & attaches a frictionless material to it.